### PR TITLE
[PIDM-2125] feat: now using new massive action retrieval endpoint

### DIFF
--- a/src/app/__tests__/Home.test.tsx
+++ b/src/app/__tests__/Home.test.tsx
@@ -1,13 +1,13 @@
 import Home from "../page"
 import { render, screen, within, waitFor } from '@testing-library/react';
-import { fetchAuthentication, fetchActions, fetchActionsByTransactionId, fetchAddActionToDeadletterTransaction, fetchDeadletterTransactionsV2, fetchNotesByTransactionIds, addNoteToTransaction, updateTransactionNote, deleteTransactionNote } from '../utils/api/client';
+import { fetchAuthentication, fetchActions, fetchActionsByTransactionId, fetchActionsByMultipleTransactionIds, fetchAddActionToDeadletterTransaction, fetchDeadletterTransactionsV2, fetchNotesByTransactionIds, addNoteToTransaction, updateTransactionNote, deleteTransactionNote } from '../utils/api/client';
 import React from "react";
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { decodeJwt } from 'jose';
 import { JwtUser } from "@pagopa/mui-italia";
 import { getTokenFromUrl } from "../utils/utils";
-import { deadletterResponse } from "./mock/DataMocks";
+import { deadletterResponse, multipleTransactionIdsActions } from "./mock/DataMocks";
 
 
 // Mocks
@@ -15,6 +15,7 @@ jest.mock('../utils/api/client', () => ({
   fetchAuthentication: jest.fn(),
   fetchActions: jest.fn(),
   fetchActionsByTransactionId: jest.fn(),
+  fetchActionsByMultipleTransactionIds: jest.fn(),
   fetchAddActionToDeadletterTransaction: jest.fn(),
   fetchDeadletterTransactionsV2: jest.fn(),
   fetchNotesByTransactionIds: jest.fn(),
@@ -43,6 +44,7 @@ jest.mock('../utils/utils', () => ({
 const mockedFetchAuthentication = fetchAuthentication as jest.Mock;
 const mockedFetchActions = fetchActions as jest.Mock;
 const mockedFetchActionsByTransactionId = fetchActionsByTransactionId as jest.Mock;
+const mockedFetchActionsByMultipleTransactionIds = fetchActionsByMultipleTransactionIds as jest.Mock;
 const mockedFetchAddActionToDeadletterTransaction = fetchAddActionToDeadletterTransaction as jest.Mock;
 const mockedFetchDeadletterTransactionsV2 = fetchDeadletterTransactionsV2 as jest.Mock;
 const mockedFetchNotesByTransactionIds = fetchNotesByTransactionIds as jest.Mock;
@@ -80,6 +82,7 @@ describe('Home', () => {
     mockedFetchAuthentication.mockReset();
     mockedFetchActions.mockReset();
     mockedFetchActionsByTransactionId.mockReset();
+    mockedFetchActionsByMultipleTransactionIds.mockReset();
     mockedFetchAddActionToDeadletterTransaction.mockReset();
     mockedFetchDeadletterTransactionsV2.mockReset();
     mockedFetchNotesByTransactionIds.mockReset();
@@ -215,7 +218,7 @@ describe('Home', () => {
     // Mock the api
     mockedFetchDeadletterTransactionsV2.mockResolvedValue(deadletterResponse);
     mockedFetchNotesByTransactionIds.mockResolvedValue([]);
-    mockedFetchActionsByTransactionId.mockResolvedValue([]);
+    mockedFetchActionsByMultipleTransactionIds.mockResolvedValue(multipleTransactionIdsActions);
     mockedFetchActions.mockResolvedValue([]);
 
     renderComponent();
@@ -246,7 +249,7 @@ describe('Home', () => {
 
     expect(mockedFetchDeadletterTransactionsV2).toHaveBeenCalled();
     expect(mockedFetchNotesByTransactionIds).toHaveBeenCalled();
-    expect(mockedFetchActionsByTransactionId).toHaveBeenCalled();
+    expect(mockedFetchActionsByMultipleTransactionIds).toHaveBeenCalled();
 
   });
 
@@ -265,7 +268,7 @@ describe('Home', () => {
     // Mock the api
     mockedFetchDeadletterTransactionsV2.mockResolvedValue(null);
     mockedFetchNotesByTransactionIds.mockResolvedValue([]);
-    mockedFetchActionsByTransactionId.mockResolvedValue([]);
+    mockedFetchActionsByMultipleTransactionIds.mockResolvedValue(multipleTransactionIdsActions);
     mockedFetchActions.mockResolvedValue([]);
 
     renderComponent();
@@ -298,14 +301,14 @@ describe('Home', () => {
 
     expect(mockedFetchDeadletterTransactionsV2).toHaveBeenCalled();
     expect(mockedFetchNotesByTransactionIds).not.toHaveBeenCalled();
-    expect(mockedFetchActionsByTransactionId).not.toHaveBeenCalled();
+    expect(mockedFetchActionsByMultipleTransactionIds).not.toHaveBeenCalled();
   });
 
   it('check if not logged no table or charts is showed', async () => {
     // Mock the api
     mockedFetchDeadletterTransactionsV2.mockResolvedValue(deadletterResponse);
     mockedFetchNotesByTransactionIds.mockResolvedValue([]);
-    mockedFetchActionsByTransactionId.mockResolvedValue([]);
+    mockedFetchActionsByMultipleTransactionIds.mockResolvedValue(multipleTransactionIdsActions);
     mockedFetchActions.mockResolvedValue([]);
 
     renderComponent();
@@ -329,7 +332,7 @@ describe('Home', () => {
 
     expect(mockedFetchDeadletterTransactionsV2).not.toHaveBeenCalled();
     expect(mockedFetchNotesByTransactionIds).not.toHaveBeenCalled();
-    expect(mockedFetchActionsByTransactionId).not.toHaveBeenCalled();
+    expect(mockedFetchActionsByMultipleTransactionIds).not.toHaveBeenCalled();
 
   });
 

--- a/src/app/__tests__/mock/DataMocks.tsx
+++ b/src/app/__tests__/mock/DataMocks.tsx
@@ -1,3 +1,4 @@
+import { DeadletterAction } from "@/app/types/DeadletterAction";
 import { DeadletterResponse } from "../../types/DeadletterResponse";
 
 
@@ -131,3 +132,18 @@ export const emptyDeadletterResponse: DeadletterResponse = {
     results: 0
   }
 }
+
+export const multipleTransactionIdsActions: DeadletterAction[][] = [
+  [
+    {
+      id: "mockId",
+      deadletterTransactionId: "mockTransactionId",
+      userId: "mockUserId",
+      action: {
+        value: "mockAction",
+        type: "FINAL"
+      },
+      timestamp: "2026-01-01T00:00:00Z"
+    }
+  ]
+]

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import styles from "./page.module.css";
 import { Transaction } from "./types/DeadletterResponse";
 import {
   fetchActions,
-  fetchActionsByTransactionId,
+  fetchActionsByMultipleTransactionIds,
   fetchAddActionToDeadletterTransaction,
   fetchDeadletterTransactionsV2,
   fetchNotesByTransactionIds,
@@ -189,18 +189,17 @@ export default function Home() {
       }
 
       const newActionsMap: Map<string, Map<string, DeadletterAction>> = new Map();
-      await Promise.all(
-        transactionsList.map(async (transaction) => {
-          if (token.current) {
-            const fileActions = await fetchActionsByTransactionId(token.current, transaction.transactionId);
-            const singleActionMap: Map<string, DeadletterAction> = new Map();
-            for (const act of fileActions) {
-              singleActionMap.set(act.action.value, act);
-            }
-            newActionsMap.set(transaction.transactionId, singleActionMap);
-          }
-        })
-      );
+      if (token.current && transactionIds?.size > 0) {
+        const nestedActionsList = await fetchActionsByMultipleTransactionIds(token.current, transactionIds)
+        for (const actions of nestedActionsList) {
+          const singleActionMap: Map<string, DeadletterAction> = actions.reduce(
+            (acc, item) => {acc.set(item.action.value, item); return acc},
+            new Map()
+          );
+          newActionsMap.set(actions[0]?.deadletterTransactionId, singleActionMap);
+        }
+      }
+
       setActionsMap((prev) => {
         if (page === 0) return newActionsMap;
         const map = new Map(prev);

--- a/src/app/utils/__tests__/api/client.test.ts
+++ b/src/app/utils/__tests__/api/client.test.ts
@@ -5,6 +5,7 @@ import { ActionType, DeadletterAction } from "@/app/types/DeadletterAction";
 import {
   fetchActions,
   fetchActionsByTransactionId,
+  fetchActionsByMultipleTransactionIds,
   fetchAddActionToDeadletterTransaction,
   fetchAuthentication,
   fetchDeadletterTransactionsV2,
@@ -172,6 +173,52 @@ describe("fetchActionsByTransactionId", () => {
     const result = await fetchActionsByTransactionId(
       mockToken,
       mockTransactionId
+    );
+
+    expect(result).toEqual([]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+  });
+});
+
+describe("fetchActionsByMultipleTransactionIds", () => {
+  it("should return DeadletterAction[][] on a successful fetch (200)", async () => {
+    jest.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue([mockDeadletterActionArray]),
+    } as unknown as Response);
+
+    const mockTransactionIds = new Set([mockTransactionId]);
+    const result = await fetchActionsByMultipleTransactionIds(
+      mockToken,
+      mockTransactionIds
+    );
+
+    expect(result).toEqual([mockDeadletterActionArray]);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      `https://api.mock.com/v2/deadletter-transactions/actions`,
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${mockToken}`, "Content-Type": "application/json" },
+        body: JSON.stringify({transactionIds: Array.from(mockTransactionIds)})
+      }
+    );
+  });
+
+  it("should return an empty array on a non-ok status", async () => {
+    jest.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+    } as unknown as Response);
+    const error = new Error(`Failed to fetch actions for ${new Set([mockTransactionId])}`);
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => { });
+
+    const mockTransactionIds = new Set([mockTransactionId]);
+    const result = await fetchActionsByMultipleTransactionIds(
+      mockToken,
+      mockTransactionIds
     );
 
     expect(result).toEqual([]);

--- a/src/app/utils/api/client.ts
+++ b/src/app/utils/api/client.ts
@@ -39,7 +39,23 @@ export const fetchActionsByTransactionId = async (token: string, transactionId: 
   }
 };
 
-
+export const fetchActionsByMultipleTransactionIds = async (token: string, transactionIds: Set<string>): Promise<DeadletterAction[][]> => {
+  try {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_ECOMMERCE_WATCHDOG_SERVICE_API_HOST}/v2/deadletter-transactions/actions`, {
+      method: "POST",
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({transactionIds: Array.from(transactionIds)})
+    });
+    if (!res.ok) throw new Error(`Failed to fetch actions for ${transactionIds}`);
+    return await res.json();
+  } catch (e) {
+    console.error(e);
+    return [];
+  }
+};
 
 export const fetchDeadletterTransactionsV2 = async (token: string, fromDate: string, toDate: string, pageNumber: number = 0, pageSize: number = 2): Promise<DeadletterResponse | null> => {
   try {


### PR DESCRIPTION
#### List of Changes
Swapped action retrieval endpoint from single to massive when loading the entire data grid

#### Motivation and Context

#### How Has This Been Tested?
Manual + Unit tests

#### Screenshots (if appropriate):

#### Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.