### PR TITLE
[PIDM-2219] Added complete / partial CSV export

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
-version: 2.19.0
-appVersion: "1.19.0"
+version: 2.20.0
+appVersion: "1.20.0"
 name: pagopa-ecommerce-watchdog-deadletter-fe
 description: Rect Typescript frontend application designed to support deadletter monitoring for the eCommerce transactions process.
 dependencies:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-ecommerce-watchdog-deadletter-fe"
   image:
     repository: pagopadcommonacr.azurecr.io/pagopaecommercewatchdogdeadletterfe
-    tag: "1.19.0"
+    tag: "1.20.0"
     pullPolicy: Always
   livenessProbe:
     handlerType: httpGet

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-ecommerce-watchdog-deadletter-fe"
   image:
     repository: pagopapcommonacr.azurecr.io/pagopaecommercewatchdogdeadletterfe
-    tag: "1.19.0"
+    tag: "1.20.0"
     pullPolicy: Always
   livenessProbe:
     handlerType: httpGet

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-ecommerce-watchdog-deadletter-fe"
   image:
     repository: pagopaucommonacr.azurecr.io/pagopaecommercewatchdogdeadletterfe
-    tag: "1.19.0"
+    tag: "1.20.0"
     pullPolicy: Always
   livenessProbe:
     handlerType: httpGet

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagopa-ecommerce-watchdog-deadletter-fe",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "private": true,
   "scripts": {
     "dev": "next dev --webpack",
@@ -22,6 +22,7 @@
     "@mui/system": "^5.14.5",
     "@mui/x-date-pickers": "7.14.0",
     "@pagopa/mui-italia": "1.6.1",
+    "csv-stringify": "^6.8.1",
     "jose": "^6.1.0",
     "material-react-table": "2.13.2",
     "next": "16.2.9",

--- a/src/app/components/SectionHeader.tsx
+++ b/src/app/components/SectionHeader.tsx
@@ -2,7 +2,7 @@ import { Box, Grid } from "@mui/material";
 
 interface SectionHeaderProps {
   icon: string;
-  title: string;
+  title: string | JSX.Element;
   subtitle: string;
   color?: string;
 }

--- a/src/app/components/TransactionsTable.tsx
+++ b/src/app/components/TransactionsTable.tsx
@@ -1,5 +1,5 @@
 import { Transaction } from "@/app/types/DeadletterResponse";
-import { Box, Chip, Divider, MenuItem, Select, IconButton, Typography, Badge, Stack, Tooltip } from "@mui/material";
+import { Box, Chip, Divider, MenuItem, Select, IconButton, Typography, Badge, Stack, Tooltip, Button, ButtonGroup, FormControl, InputLabel, TextField, CircularProgress } from "@mui/material";
 import { getDeadletterActionAsString } from "@/app/utils/types/DeadletterActionUtils";
 import { DeadletterAction, ActionType } from "../types/DeadletterAction";
 import { dateTimeLocale, extendedMonthDateFormatOptions, utcDateTimeFormatOptions } from "../utils/datetimeFormatConfig";
@@ -10,6 +10,9 @@ import AddCommentIcon from '@mui/icons-material/AddComment';
 import { useMemo, useState } from "react";
 import TransactionNotesDrawer from "./TransactionNotesDrawer";
 import { getSuggestedAction } from "../utils/SuggestedActionsRules";
+import { FileDownload } from "@mui/icons-material";
+import { exportConfigs, ExportType } from "../utils/csvExportConfig";
+import { stringify } from "csv-stringify/sync";
 
 export function TransactionsTable(
   props: Readonly<{
@@ -18,6 +21,9 @@ export function TransactionsTable(
     actionsMap: Map<string, Map<string, DeadletterAction>>;
     actions: ActionType[];
     userId: string;
+    startDate?: string;
+    endDate?: string;
+    isLoadingData: boolean;
     handleOpenDialog: (content: object) => void;
     handleAddActionToTransaction: (actionType: string, id: string) => void;
     handleAddNote: (transactionId: string, text: string) => void;
@@ -26,6 +32,101 @@ export function TransactionsTable(
     rowCount?: number;
   }>
 ) {
+
+  const [filtroPredefinito, setFiltroPredefinito] = useState<ExportType>('all_range');
+  const [loadingExport, setLoadingExport] = useState(false);
+
+  const setVisibleColumns = (columns: string[]) => {
+    table.toggleAllColumnsVisible(false);
+    table.setColumnVisibility((prev) => Object.fromEntries(
+        Object.keys(prev).map((key) =>
+          ['mrt-row-select', 'mrt-row-numbers', ...columns,  'actions', 'notes'].includes(key) ? [key, true] : [key, false]
+        )
+      )
+    );
+  }
+
+  const handleTableFilterRule = (type: ExportType) => {
+    setFiltroPredefinito(type);
+    switch (type) {
+      case "all_range": {
+        table.resetColumnVisibility();
+        table.resetColumnFilters();
+        return;
+      }
+      case "bancomat_pay": {
+        setVisibleColumns(exportConfigs[type].columns);
+        table.setColumnFilters([
+          {id: 'gatewayAuthorizationStatus', value: ['PENDING', null, 'null']},
+          {id: 'paymentMethodName', value: ['BANCOMATPAY']}
+        ]);
+
+        return;
+      }
+      case "mybank_intesa": {
+        setVisibleColumns(exportConfigs[type].columns);
+        table.setColumnFilters([
+          {id: 'paymentMethodName', value: ['MYBANK']},
+          {id: 'eCommerceStatus', value: ['REFUND_ERROR']},
+          {id: 'pspId', value: ['BCITITMM']},
+        ]);
+        return;
+      }
+      case "mybank_unicredit": {
+        setVisibleColumns(exportConfigs[type].columns);
+        table.setColumnFilters([
+          {id: 'paymentMethodName', value: ['MYBANK']},
+          {id: 'eCommerceStatus', value: ['REFUND_ERROR']},
+          {id: 'pspId', value: ['UNCRITMM']},
+        ]);
+        return;
+      }
+    }
+  }
+
+  function handleExportCSV(type: ExportType): void;
+  function handleExportCSV(): void;
+  function handleExportCSV(type?: ExportType) {
+    setLoadingExport(true);
+    const onlySelected: boolean = type == undefined;
+    type = type ?? 'all_range';
+
+    const transformed_rows = (onlySelected ? table.getSelectedRowModel() : table.getRowModel())
+      .rows.map(
+        (row) => {
+          const r: Record<string, any> = {};
+          row.getAllCells()
+            .forEach(c => r[c.column.columnDef.accessorKey!] = c.getValue() ?? "")
+          return r;
+        }
+      )
+
+    const csvContent = stringify(
+      transformed_rows,
+      { header: true, columns: exportConfigs[type].columns }
+    )
+
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const link = document.createElement('a');
+    const url = URL.createObjectURL(blob);
+
+    const dateStr = (props.startDate && props.endDate) ?
+          `${props.startDate}_${props.endDate}` :
+          new Date().toISOString().split('T')[0];
+
+    link.setAttribute('href', url);
+    if (onlySelected) {
+      link.setAttribute('download', `Selezionati_${dateStr}.csv`);
+    } else {
+      link.setAttribute('download', `${exportConfigs[type].fileNamePrefix}_${dateStr}.csv`);
+    }
+    link.style.visibility = 'hidden';
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    setLoadingExport(false);
+  }
 
   const [drawerConfig, setDrawerConfig] = useState<{ open: boolean; transactionId: string | null }>({
     open: false,
@@ -135,6 +236,7 @@ export function TransactionsTable(
         header: "Amount",
         accessorKey: "amount",
         accessorFn: (value) => value.eCommerceDetails?.transactionInfo?.grandTotal || "",
+        size: 120
       },
       {
         header: "MethodName",
@@ -425,6 +527,51 @@ export function TransactionsTable(
         width: table.getState().isFullScreen ? "99.3vw" : undefined
       },
     }),
+    renderTopToolbarCustomActions: ({ table }) => (
+      <Box sx={{ display: 'flex', gap: '1rem', p: '4px' }}>
+        <TextField 
+          select 
+          size='small' 
+          label='Filtri predefiniti'
+          value={filtroPredefinito}
+          onChange={(event) => handleTableFilterRule(event.target.value as ExportType)}
+          sx={{
+            '& .MuiSelect-select': { paddingTop: 0.8 },
+            marginRight: '4px',
+            width: 200
+          }}
+        >
+          {(Object.keys(exportConfigs) as ExportType[]).map(key => {
+            return (
+              <MenuItem key={key} value={key} data-testid={key}>
+                {exportConfigs[key].label}
+              </MenuItem>
+            );
+          })}
+        </TextField>
+        <ButtonGroup size="small" variant="contained" aria-label="Export button group">
+            <Button
+              onClick={() => handleExportCSV(filtroPredefinito)}
+              startIcon={loadingExport || props.isLoadingData ? <CircularProgress size={20} color="inherit" /> : <FileDownload />}
+              disabled={
+                table.getFilteredRowModel().rows.length == 0 ||
+                loadingExport ||
+                props.isLoadingData
+              }
+              sx={{ width: 200 }}
+            >
+              Esporta intero range ({exportConfigs[filtroPredefinito].label})
+            </Button>
+          <Button
+            disabled={!table.getIsSomeRowsSelected() && !table.getIsAllRowsSelected()}
+            onClick={() => handleExportCSV()}
+            startIcon={loadingExport ? <CircularProgress size={20} color="inherit" /> : <FileDownload />}
+          >
+            Esporta righe selezionate
+          </Button>
+        </ButtonGroup>
+      </Box>
+    ),
     muiTableBodyProps: {
       sx: {
         "& tr:nth-of-type(odd) > td": {

--- a/src/app/components/__tests__/TransactionsTable.test.tsx
+++ b/src/app/components/__tests__/TransactionsTable.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { TransactionsTable, azioniSortingFn, azioniFilterFn, noteFilterFn } from "../TransactionsTable";
 import userEvent from "@testing-library/user-event";
 import { ActionType, DeadletterAction } from "../../types/DeadletterAction";
@@ -29,6 +29,44 @@ jest.mock<typeof import('@tanstack/react-virtual')>('@tanstack/react-virtual', (
   }
 })
 
+const setupDownloadMocks = () => {
+  const mockLink = {
+    setAttribute: jest.fn(),
+    click: jest.fn(),
+    style: {} as CSSStyleDeclaration,
+  } as unknown as HTMLAnchorElement & { setAttribute: jest.Mock; click: jest.Mock };
+
+  const createElementSpy = jest.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+    if (tagName === 'a') {
+      return mockLink;
+    }
+    return Document.prototype.createElement.call(document, tagName);
+  });
+
+  const appendChildSpy = jest.spyOn(document.body, 'appendChild').mockImplementation((node: Node) => {
+    if (node === mockLink) {
+      return mockLink;
+    }
+    return Node.prototype.appendChild.call(document.body, node);
+  });
+
+  const removeChildSpy = jest.spyOn(document.body, 'removeChild').mockImplementation((node: Node) => {
+    if (node === mockLink) {
+      return mockLink;
+    }
+    return Node.prototype.removeChild.call(document.body, node);
+  });
+
+  return {
+    mockLink,
+    createElementSpy,
+    appendChildSpy,
+    removeChildSpy,
+  };
+};
+
+global.URL.createObjectURL = jest.fn(() => 'mock-url');
+global.URL.revokeObjectURL = jest.fn();
 const mockHandleOpenDialog = jest.fn();
 const mockHandleAddActionToTransaction = jest.fn();
 const mockHandleAddNote = jest.fn();
@@ -294,6 +332,8 @@ const defaultProps = {
   notesMap: mockNotesMap,
   actionsMap: mockActionsMap,
   actions: mockActionTypes,
+  startDate: "2025-07-01",
+  endDate: "2025-07-03",
   handleOpenDialog: mockHandleOpenDialog,
   handleAddActionToTransaction: mockHandleAddActionToTransaction,
   handleAddNote: mockHandleAddNote,
@@ -557,6 +597,83 @@ describe("TransactionsTable", () => {
     expect(within(row1Element).getByText(mockTransactions[0].eCommerceDetails?.transactionInfo?.grandTotal || "")).toBeInTheDocument();
     expect(within(row1Element).getByText(mockAction1.action.value)).toBeInTheDocument();
     expect(within(row1Element).getByText(mockAction2.action.value)).toBeInTheDocument();
+  });
+
+  it("changes columns and rows when selecting a predefined filter", async () => {
+    renderComponent();
+    const user = userEvent.setup();
+
+    // Find predefined filter button
+    const columnButton = screen.getByText("Tutte le transazioni");
+    expect(columnButton).toBeInTheDocument();
+    await user.click(columnButton);
+
+    // Select filter MyBank Intesa
+    const myBankIntesaOption = screen.getByText("MyBank Intesa");
+    expect(myBankIntesaOption).toBeInTheDocument();
+    await user.click(myBankIntesaOption);
+
+    // Check column headers
+    expect(screen.queryByText("transactionId")).toBeInTheDocument();
+    expect(screen.queryByText("insertionDate (UTC)")).toBeInTheDocument();
+    expect(screen.queryByText(/PaymentToken/i)).toBeInTheDocument();
+    expect(screen.queryByText(/AuthorizationRequestId/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/MethodName/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("pspId")).not.toBeInTheDocument();
+    expect(screen.queryByText("statoEcommerce")).not.toBeInTheDocument();
+    expect(screen.queryByText("nodoStatus")).not.toBeInTheDocument();
+    expect(screen.queryByText("gatewayStatus")).not.toBeInTheDocument();
+    expect(screen.queryByText("Azioni")).toBeInTheDocument();
+    expect(screen.queryByText("PaymentEndToEndId")).toBeInTheDocument();
+    expect(screen.queryByText("Amount")).not.toBeInTheDocument();
+
+    // Select filter BancomatPay
+    await user.click(columnButton);
+    const bancomatPayOption = screen.getByText("BancomatPay");
+    expect(bancomatPayOption).toBeInTheDocument();
+    await user.click(bancomatPayOption);
+
+    // Check some column headers changes
+    expect(screen.queryByText("PaymentEndToEndId")).not.toBeInTheDocument();
+    expect(screen.queryByText("gatewayStatus")).toBeInTheDocument();
+
+    // Select filter MyBank Unicredit
+    await user.click(columnButton);
+    const myBankUnicreditOption = screen.getByText("MyBank Unicredit");
+    expect(myBankUnicreditOption).toBeInTheDocument();
+    await user.click(myBankUnicreditOption);
+
+    // Check some column headers changes
+    expect(screen.queryByText("PaymentEndToEndId")).toBeInTheDocument();
+    expect(screen.queryByText("gatewayStatus")).not.toBeInTheDocument();
+
+    // Select no filter
+    await user.click(columnButton);
+    const defaultOption = screen.getByText("Tutte le transazioni");
+    expect(defaultOption).toBeInTheDocument();
+    await user.click(defaultOption);
+
+    // Check some column headers changes
+    expect(screen.queryByText("PaymentEndToEndId")).not.toBeInTheDocument();
+    expect(screen.queryByText("gatewayStatus")).toBeInTheDocument();
+    expect(screen.queryByText("nodoStatus")).toBeInTheDocument();
+  });
+
+
+  it('should trigger CSV download when export button is clicked', async () => {
+    renderComponent();
+    const user = userEvent.setup();
+
+    const downloadMocks = setupDownloadMocks();
+
+    const exportButton = screen.getByRole('button', { name: /Esporta intero range.*/i });
+    await user.click(exportButton);
+
+    await waitFor(() => {
+      expect(downloadMocks.mockLink.setAttribute).toHaveBeenCalledWith('download', 'Tutte_Transazioni_2025-07-01_2025-07-03.csv');
+      expect(downloadMocks.mockLink.setAttribute).toHaveBeenCalledWith('href', 'mock-url');
+      expect(downloadMocks.mockLink.click).toHaveBeenCalled();
+    });
   });
 
   describe("azioniSortingFn", () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,7 @@ import { TransactionDetails } from "./components/TransactionDetails";
 import { dateTimeLocale, extendedMonthDateFormatOptions } from "./utils/datetimeFormatConfig";
 import { TransactionNote } from "./types/TransactionNotes";
 import LinearProgress from '@mui/material/LinearProgress';
-import { Paper } from "@mui/material";
+import { Chip, Paper } from "@mui/material";
 import { TransactionsTable } from "./components/TransactionsTable";
 
 
@@ -132,7 +132,7 @@ export default function Home() {
     }
   }
 
-  const loadDataForRange = async (start: string, end: string, page: number = 0, pageSize: number = 20) => {
+  const loadDataForRange = async (start: string, end: string, page: number = 0, pageSize: number = 100) => {
     if (!start || !end || !token.current) {
       setTransactions([]);
       return;
@@ -155,7 +155,7 @@ export default function Home() {
     } else {
       setIsLoadingMore(true);
       if (page >= 4) {
-        await new Promise(resolve => setTimeout(resolve, 2000));
+        await new Promise(resolve => setTimeout(resolve, 1000));
       }
     }
 
@@ -227,7 +227,7 @@ export default function Home() {
     let timeoutId: NodeJS.Timeout;
 
     if (hasMore && !isLoadingMore && !loadingData && rangeStart && rangeEnd) {
-      // Initiate next fetch after a small delay (the 2s delay is inside loadDataForRange but we can do it here too, however we already do `await new Promise` in loadDataForRange)
+      // Initiate next fetch after a small delay (the 1s delay is inside loadDataForRange but we can do it here too, however we already do `await new Promise` in loadDataForRange)
       timeoutId = setTimeout(() => {
         setPaginationModel((prev) => {
           const nextModel = { ...prev, page: prev.page + 1 };
@@ -387,7 +387,12 @@ export default function Home() {
 
             <SectionHeader
               icon="⚡"
-              title="Azioni Rapide"
+              title={
+                <>
+                Azioni Rapide
+                <Chip label="⚠️ Discontinued" variant="outlined" color="error" sx={{ marginLeft: 12 }}/>
+                </>
+              }
               subtitle="Export CSV per gestione storni e tanto altro"
             />
 
@@ -436,13 +441,16 @@ export default function Home() {
 
 
             <Grid item xs={12}>
-              <Paper sx={{ height: "100%", width: "100%" }}>
+              <Paper sx={{ height: "100%", width: "100%", minHeight: "600px" }}>
                 <TransactionsTable
                   transactions={transactions}
                   notesMap={notesMap}
                   actionsMap={actionsMap}
                   actions={actions}
                   userId={jwtUser?.id || ""}
+                  startDate={rangeStart}
+                  endDate={rangeEnd}
+                  isLoadingData={loadingData || hasMore}
                   handleOpenDialog={handleOpenDialog}
                   handleAddActionToTransaction={handleAddActionToTransaction}
                   handleAddNote={handleAddNote}

--- a/src/app/utils/__tests__/csvExportConfig.test.ts
+++ b/src/app/utils/__tests__/csvExportConfig.test.ts
@@ -284,7 +284,7 @@ describe('csvExportConfig', () => {
         'nodoStatus',
         'paymentEndToEndId',
         'authorizationRequestId',
-        'Amount'
+        'amount'
       ]);
     });
   });

--- a/src/app/utils/csvExportConfig.tsx
+++ b/src/app/utils/csvExportConfig.tsx
@@ -75,7 +75,7 @@ export const exportConfigs: Record<ExportType, ExportConfig> = {
     label: "Tutte le transazioni",
     description: "Tutte le transazioni nel range selezionato",
     filter: () => true,
-    columns: ['insertionDate', 'transactionId', 'paymentToken', 'paymentMethodName', 'pspId', 'eCommerceStatus', 'gatewayAuthorizationStatus', 'nodoStatus', 'paymentEndToEndId', 'authorizationRequestId', "Amount"],
+    columns: ['insertionDate', 'transactionId', 'paymentToken', 'paymentMethodName', 'pspId', 'eCommerceStatus', 'gatewayAuthorizationStatus', 'nodoStatus', 'paymentEndToEndId', 'authorizationRequestId', "amount"],
     getColumnValue: (transaction, column) => {
       if (column === 'insertionDate') {
         const date = transaction.insertionDate;
@@ -84,7 +84,7 @@ export const exportConfigs: Record<ExportType, ExportConfig> = {
         return dateObj.toISOString().split('.')[0];
       } else if (column === 'authorizationRequestId') {
         return transaction.eCommerceDetails?.transactionInfo?.authorizationRequestId || '';
-      } else if (column === 'Amount') {
+      } else if (column === 'amount') {
         return transaction.eCommerceDetails?.transactionInfo?.grandTotal.toString() || '';
       }
       return transaction[column as keyof Transaction] as string || '';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2549,6 +2549,11 @@ csstype@^3.0.2, csstype@^3.1.3, csstype@^3.2.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
+csv-stringify@^6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-6.8.1.tgz#4f79eebedaa421ca1bae88fddae92cdb4a11008f"
+  integrity sha512-tZ6X6TKQyQgCo5OptXcyAbfN1pwmoxEqELPQ7KFazNErx7kiVsDK8o+VYRXhfMl4N9vvOOLXuioquR2MeP847A==
+
 "d3-array@2 - 3", "d3-array@2.10.0 - 3", d3-array@^3.1.6:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"


### PR DESCRIPTION
#### List of Changes
1. Added existing predefined set of filter on the table to show immediate feedback
2. Added button to export based on predefined filter selected
3. Added button to export only selected rows

Changes 1 & 2 are able to replace the section "Azioni Rapide" with the benefit that doesn't make another API call but
rather uses the already loaded data.
("Azioni Rapide" will still be available)

#### Motivation and Context

#### How Has This Been Tested?

#### Screenshots (if appropriate):
<img width="1680" height="774" alt="immagine" src="https://github.com/user-attachments/assets/e2e57c8c-0083-4d3a-98bc-e56758c59159" />
<img width="1492" height="822" alt="immagine" src="https://github.com/user-attachments/assets/ca7b7277-cacc-441f-8119-374ad1934160" />

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.