### PR TITLE
fix(ux-actions): PIDM-2125 standardize transaction ID field and improve action mapping logic

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,3 +1,6 @@
 NEXT_PUBLIC_ECOMMERCE_WATCHDOG_SERVICE_API_HOST=http://localhost:4000
 NEXT_PUBLIC_ECOMMERCE_WATCHDOG_AUTH_API_HOST=http://localhost:4000
 NEXT_PUBLIC_ECOMMERCE_WATCHDOG_BASE_PATH=/
+#Use this configuration locally with the UAT API, and update the environment configuration accordingly.
+#NEXT_PUBLIC_ECOMMERCE_WATCHDOG_SERVICE_API_HOST=/api-proxy/pagopa-ecommerce-watchdog-deadletter-service
+#NEXT_PUBLIC_ECOMMERCE_WATCHDOG_AUTH_API_HOST=/api-proxy/pagopa-ecommerce-watchdog-deadletter-service

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,15 @@ const nextConfig: NextConfig = {
   /* config options here */
   output: 'standalone',
   assetPrefix: '/pagopa-ecommerce-watchdog-deadletter-fe',
+  /* Use this configuration locally with the UAT API, and update the environment configuration accordingly. */
+  // async rewrites() {
+  //   return [
+  //     {
+  //       source: '/api-proxy/:path*',
+  //       destination: 'https://weuuat.ecommerce.internal.uat.platform.pagopa.it/:path*',
+  //     },
+  //   ];
+  // },
 };
 
 export default nextConfig;

--- a/src/app/__tests__/mock/DataMocks.tsx
+++ b/src/app/__tests__/mock/DataMocks.tsx
@@ -137,7 +137,7 @@ export const multipleTransactionIdsActions: DeadletterAction[][] = [
   [
     {
       id: "mockId",
-      deadletterTransactionId: "mockTransactionId",
+      transactionId: "mockTransactionId",
       userId: "mockUserId",
       action: {
         value: "mockAction",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -115,6 +115,7 @@ export default function Home() {
       timestamp: new Date().toISOString(),
       userId: jwtUser.id,
       deadletterTransactionId: id,
+      transactionId: id,
       action: actionType
     }
 
@@ -160,6 +161,7 @@ export default function Home() {
               timestamp: new Date().toISOString(),
               userId: jwtUser.id,
               deadletterTransactionId: t.transactionId,
+              transactionId: t.transactionId,
               action: actionType
             }
 
@@ -204,8 +206,8 @@ export default function Home() {
     try {
       const data = await fetchDeadletterTransactionsV2(token.current!, start, end, page, pageSize);
       const transactionsList = data?.deadletterTransactions
-            .sort((a, b) => new Date(a.insertionDate).valueOf() - new Date(b.insertionDate).valueOf())
-            || [];
+        .sort((a, b) => new Date(a.insertionDate).valueOf() - new Date(b.insertionDate).valueOf())
+        || [];
 
       if (page === 0) {
         setTransactions(transactionsList);
@@ -240,11 +242,15 @@ export default function Home() {
       if (token.current && transactionIds?.size > 0) {
         const nestedActionsList = await fetchActionsByMultipleTransactionIds(token.current, transactionIds)
         for (const actions of nestedActionsList ?? []) {
+          if (!actions || actions.length === 0) continue;
           const singleActionMap: Map<string, DeadletterAction> = actions.reduce(
-            (acc, item) => {acc.set(item.action.value, item); return acc},
+            (acc, item) => { acc.set(item.action.value, item); return acc },
             new Map()
           );
-          newActionsMap.set(actions[0]?.deadletterTransactionId, singleActionMap);
+          const tId = actions[0]?.transactionId || actions[0]?.deadletterTransactionId;
+          if (tId) {
+            newActionsMap.set(tId, singleActionMap);
+          }
         }
       }
 
@@ -431,8 +437,8 @@ export default function Home() {
               icon="⚡"
               title={
                 <>
-                Azioni Rapide
-                <Chip label="⚠️ Discontinued" variant="outlined" color="error" sx={{ marginLeft: 12 }}/>
+                  Azioni Rapide
+                  <Chip label="⚠️ Discontinued" variant="outlined" color="error" sx={{ marginLeft: 12 }} />
                 </>
               }
               subtitle="Export CSV per gestione storni e tanto altro"

--- a/src/app/types/DeadletterAction.ts
+++ b/src/app/types/DeadletterAction.ts
@@ -1,6 +1,7 @@
 export interface DeadletterAction {
   id: string;
-  deadletterTransactionId: string;
+  deadletterTransactionId?: string;
+  transactionId?: string;
   userId: string;
   action: ActionType;
   timestamp: string;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Added a rewrite rule in [next.config.ts](cci:7://file:///Users/simone.infante/Documents/GitHub/pagopa-ecommerce-watchdog-deadletter-fe/next.config.ts:0:0-0:0) to proxy requests to `/api-proxy/:path*` directly to the remote backend, avoiding CORS issues.
- Updated [.env.local](cci:7://file:///Users/simone.infante/Documents/GitHub/pagopa-ecommerce-watchdog-deadletter-fe/.env.local:0:0-0:0) to point API hosts to the local proxy.
- Fixed an actions parsing bug in [page.tsx](cci:7://file:///Users/simone.infante/Documents/GitHub/pagopa-ecommerce-watchdog-deadletter-fe/src/app/page.tsx:0:0-0:0): added fallback to match actions via `transactionId` instead of just `deadletterTransactionId`, matching the real backend payload structure.
- Updated [DeadletterAction](cci:2://file:///Users/simone.infante/Documents/GitHub/pagopa-ecommerce-watchdog-deadletter-fe/src/app/types/DeadletterAction.ts:0:0-7:1) type in [src/app/types/DeadletterAction.ts](cci:7://file:///Users/simone.infante/Documents/GitHub/pagopa-ecommerce-watchdog-deadletter-fe/src/app/types/DeadletterAction.ts:0:0-0:0) to include `transactionId?`.
- Updated test mocks in [DataMocks.tsx](cci:7://file:///Users/simone.infante/Documents/GitHub/pagopa-ecommerce-watchdog-deadletter-fe/src/app/__tests__/mock/DataMocks.tsx:0:0-0:0) to use `transactionId`, correctly simulating production behavior.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR solves two issues:
1. **Local Development (CORS):** Attempting to run the app locally against an external development/UAT backend caused CORS errors due to direct browser requests. The rewrite acts as a proxy to bypass them.
2. **Invisible Actions Bug:** The actions fetched from the API were returning `200 OK` but were not displayed in the UI table. The real API returns `transactionId` while the frontend (based on older mocks) expected `deadletterTransactionId`. The grouping logic was silently failing and has now been made robust.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Verified locally that the proxy rewrite successfully eliminates CORS constraints when hitting the remote API.
- Verified the correct UI rendering of the actions within the [TransactionsTable](cci:1://file:///Users/simone.infante/Documents/GitHub/pagopa-ecommerce-watchdog-deadletter-fe/src/app/components/TransactionsTable.tsx:16:0-673:1) using the real backend data.
- Executed `yarn test`: all 176 unit tests pass with 100% success against the updated mock structural logic.

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.