### PR TITLE
Fixed chart not counting actions correctly and ignoring transactions with no actions + changed actions order inside rows

### DIFF
--- a/src/app/components/ChartsStatistics.tsx
+++ b/src/app/components/ChartsStatistics.tsx
@@ -58,19 +58,19 @@ export default function ChartsStatistics(
     const grouped = new Map<string, number>();
     grouped.set(FINAL_STATUS, 0);
     grouped.set(NON_FINAL_STATUS, 0);
-    grouped.set(NON_ANALYZED_STATUS, 0);
+    grouped.set(NON_ANALYZED_STATUS, props.transactions.length);
 
     for (const transactionActionMap of actionsMap.values()) {
-      if (transactionActionMap.size === 0) {
-        grouped.set(NON_ANALYZED_STATUS, grouped.get(NON_ANALYZED_STATUS)! + 1);
-        continue;
-      }
       for (const actionItem of transactionActionMap.values()) {
-        if (actionItem.action.type === "FINAL") {
-          grouped.set(FINAL_STATUS, grouped.get(FINAL_STATUS)! + 1);
-        } else {
-          grouped.set(NON_FINAL_STATUS, grouped.get(NON_FINAL_STATUS)! + 1);
+        switch (actionItem.action.type) {
+          case "FINAL":
+            grouped.set(FINAL_STATUS, grouped.get(FINAL_STATUS)! + 1);
+            break;
+          case "NOT_FINAL":
+            grouped.set(NON_FINAL_STATUS, grouped.get(NON_FINAL_STATUS)! + 1);
+            break;
         }
+        grouped.set(NON_ANALYZED_STATUS, Math.max(grouped.get(NON_ANALYZED_STATUS)! - 1, 0))
       }
     }
     return Array.from(grouped.entries()).map(([name, value]) => ({
@@ -93,7 +93,19 @@ export default function ChartsStatistics(
   );
 
   const actionTypes = useMemo(
-    () => groupActionsByType(props.actionsMap),
+    () => {
+      const latestActions: Map<string, Map<string, DeadletterAction>> = new Map();
+
+      for (const [tId, actions] of props.actionsMap) {
+        if (actions.size == 0) continue;
+        const latest = actions.entries().reduce(
+          (acc, value) => new Date(acc[1].timestamp).valueOf() > new Date(value[1].timestamp).valueOf() ?
+          acc : value
+        );
+        latestActions.set(tId, new Map([latest]))
+      }
+      return groupActionsByType(latestActions)
+    },
     [props.actionsMap]
   );
 
@@ -125,7 +137,7 @@ export default function ChartsStatistics(
             >
               {chart.title}
             </Typography>
-            <ResponsiveContainer width="100%" height={250}>
+            <ResponsiveContainer width="100%" height={280}>
               <PieChart>
                 <Pie
                   data={chart.data}

--- a/src/app/components/TransactionsTable.tsx
+++ b/src/app/components/TransactionsTable.tsx
@@ -380,7 +380,7 @@ export function TransactionsTable(
         filterFn: (row, _id, filterValue) => azioniFilterFn(row, filterValue),
         Cell: ({ row }) => {
           const transactionActions = row.original.actions
-            ? Array.from(row.original.actions!.values())
+            ? Array.from(row.original.actions!.values()).sort((a,b) => new Date(b.timestamp).valueOf() - new Date(a.timestamp).valueOf())
             : [];
 
           return (

--- a/src/app/components/__tests__/ChartsStatistics.test.tsx
+++ b/src/app/components/__tests__/ChartsStatistics.test.tsx
@@ -50,6 +50,10 @@ const mockTransactions: Transaction[] = [
   } as Transaction,
 ];
 
+const date1 = new Date();
+const date2 = new Date();
+date2.setTime(date2.getTime() - 60);
+
 const mockActionsMap: Map<string, Map<string, DeadletterAction>> = new Map([
   ["t1", new Map([["a1", { action: { type: "FINAL" } } as DeadletterAction]])],
   [
@@ -59,8 +63,8 @@ const mockActionsMap: Map<string, Map<string, DeadletterAction>> = new Map([
   [
     "t3",
     new Map([
-      ["a3", { action: { type: "FINAL" } } as DeadletterAction],
-      ["a4", { action: { type: "NOT_FINAL" } } as DeadletterAction],
+      ["a3", { action: { type: "FINAL" }, timestamp: date1.toISOString() } as DeadletterAction],
+      ["a4", { action: { type: "NOT_FINAL" }, timestamp: date2.toISOString() } as DeadletterAction],
     ]),
   ],
   ["t4", new Map()],
@@ -152,7 +156,7 @@ describe("ChartsStatistics", () => {
     expect(data).toEqual(
       expect.arrayContaining([
         { name: "FINALE", value: 2 },
-        { name: "NON FINALE", value: 2 },
+        { name: "NON FINALE", value: 1 },
         { name: "NON ANALIZZATO", value: 1 },
       ])
     );


### PR DESCRIPTION
#### List of Changes
- Chart is now counting transactions with no actions correctly
- Now the actions counted are only the latest ones instead of all actions
- Inside the row, actions are now sorted from the most recent to the least recent

#### Motivation and Context

#### How Has This Been Tested?

#### Screenshots (if appropriate):
Transactions not analyzed yet are now counted correctly
<img width="3210" height="858" alt="immagine" src="https://github.com/user-attachments/assets/e57ad5bf-0be0-4528-a0fe-48a997d208d1" />

Actions inside a row are now ordered from most recent to least recent
<img width="3136" height="606" alt="immagine" src="https://github.com/user-attachments/assets/2803dbcd-9f95-49bb-abbc-297e104371e8" />

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.